### PR TITLE
fix(composer): remove version field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "jardisadapter/cache",
-    "version": "1.0.0",
     "description": "Advanced PSR-16 compliant multi-layer caching library",
     "type": "library",
     "license": "PolyForm-Noncommercial-1.0.0",


### PR DESCRIPTION
Version is managed by git tags via auto-release workflow. The version field in composer.json is unnecessary and can cause conflicts.