### PR TITLE
fix(deps): php_codesniffer 3.13.5 auf 3.13.6 (Security-Advisory)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "10.5.63",
         "phpstan/phpstan": "2.1.56",
-        "squizlabs/php_codesniffer": "3.13.5",
+        "squizlabs/php_codesniffer": "3.13.6",
         "ext-json": "*",
         "ext-redis": "*",
         "ext-apcu": "*"


### PR DESCRIPTION
## Problem

Der exakte Pin `squizlabs/php_codesniffer: 3.13.5` in `composer.json` faellt unter das
Security-Advisory **PKSA-rdkp-vv9z-mjkg** (OS Command Injection, betroffen `< 3.13.6`).
Composer verweigert mit aktivem `block-insecure` (Default) jede frische Aufloesung dieses
Pins. Damit stirbt jede CI, die von einem frischen `composer install` ausgeht, im Schritt
"Install dependencies" — bevor eine einzige Pruefung laeuft.

Vorbestehend, nicht von diesem Zug verursacht. 21 der 25 Jardis-Repos pinnen exakt 3.13.5;
dieser Zug hebt eines davon.

## Fix

Genau eine Zeile in `composer.json`: `3.13.5` -> `3.13.6` (behoben laut Advisory).

## Verifikation (lokal)

- `composer.lock` (nicht getrackt) entfernt, frisches `make install`: Exit 0, Log zeigt
  `Upgrading squizlabs/php_codesniffer (3.13.5 => 3.13.6)`.
- `make start` (Redis-Stack) -> QA sequentiell, alle gruen:
  - `make phpcs`: Exit 0
  - `make phpstan`: Exit 0
  - `make phpunit`: Exit 0 — 187 Tests, 399 Assertions, 1 Warning (vorbestehend, nicht neu)
- `make stop` danach ausgefuehrt.

## Scope

Nur `composer.json`, eine Zeile. Kein `composer.lock` committet (nicht getrackt in diesem
Repo). Kein Tag, kein Release, kein Push nach `main` — Merge nach `develop`.